### PR TITLE
Clarified macOS version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This project provides static `ffmpeg` binaries for multiple platforms and archit
 
 ## Supported Platforms
 
-| OS                     | Supported Architectures |
-|------------------------|-------------------------|
-| Raspbian Linux (9+)    | armv6l (armv7l)         |
-| Debian/Ubuntu Linux    | x86_64, armv7l, aarch64 |
-| Alpine Linux           | x86_64, armv6l, aarch64 |
-| macOS (10.14+)         | x86_64                  |
-| Windows 10<sup>*</sup> | x86_64                  |
+| OS                              | Supported Architectures |
+|---------------------------------|-------------------------|
+| Raspbian Linux (9+)             | armv6l (armv7l)         |
+| Debian/Ubuntu Linux             | x86_64, armv7l, aarch64 |
+| Alpine Linux                    | x86_64, armv6l, aarch64 |
+| macOS (10.14 "Mojave" or newer) | x86_64                  |
+| Windows 10<sup>*</sup>          | x86_64                  |
 
 <sup>*</sup> Not all codecs are supported on Windows 10.
 

--- a/install.js
+++ b/install.js
@@ -164,7 +164,11 @@ async function install() {
   const ffmpegDownloadFileName = getDownloadFileName();
 
   if (!ffmpegDownloadFileName) {
-    console.log(`ffmpeg-for-homebridge: ${os.platform()} ${process.arch} is not supported, you will need to install/compile ffmpeg manually.`);
+    if (os.platform() === 'darwin' && parseInt(os.release()) < 18) {
+      console.log(`ffmpeg-for-homebridge: macOS versions older than 10.14 "Mojave" are not supported, you will need to install/compile ffmpeg manually.`);
+    } else {
+      console.log(`ffmpeg-for-homebridge: ${os.platform()} ${process.arch} is not supported, you will need to install/compile ffmpeg manually.`);
+    }
     process.exit(0);
   }
 


### PR DESCRIPTION
There was some confusion on the Discord about macOS version support, since the error message in that case just says Darwin x64 is not supported. This PR clarifies both that error message and the readme.