### PR TITLE
Fix package.json typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "files": [
     "install.js",
     "index.js",
-    "index.d.js"
+    "index.d.ts"
   ],
   "keywords": [
     "homebridge",


### PR DESCRIPTION
Managed to make a typo I didn't notice in the last pull request that prevented the type file from actually being pulled into the package. Sorry about that, I didn't think of running an npm dry-run before the last PR.