### PR TITLE
Revert Mac ARM build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,7 @@ jobs:
           alpine-x86_64,
           alpine-armv6l,
           alpine-aarch64,
-          darwin-x86_64,
-          darwin-arm64
+          darwin-x86_64
         ]
         include:
           - name: raspbian-armv6l
@@ -59,8 +58,6 @@ jobs:
             DOCKERFILE: Dockerfile.alpine
             TARGET_OS: alpine
           - name: darwin-x86_64
-            os: macOS-latest
-          - name: darwin-arm64
             os: macOS-latest
 
     steps:

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -26,7 +26,7 @@ elif [[ -f /proc/cpuinfo ]]; then
     MJOBS=$(grep -c processor /proc/cpuinfo)
 elif [[ "$OSTYPE" == "darwin"* ]]; then
 	MJOBS=$(sysctl -n machdep.cpu.thread_count)
-	ADDITIONAL_CONFIGURE_OPTIONS="--enable-videotoolbox --arch=arm64"
+	ADDITIONAL_CONFIGURE_OPTIONS="--enable-videotoolbox"
 else
     MJOBS=4
 fi

--- a/install.js
+++ b/install.js
@@ -13,7 +13,7 @@ const tar = require('tar');
 
 function getNpmPackageVersion() {
   // return 'v' + process.env.npm_package_version;
-  return 'v0.0.10';
+  return 'v0.0.11';
 }
 
 function npmCache() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-for-homebridge",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Static ffmpeg binaries for Homebridge with support for audio (libfdk-aac) and hardware decoding (h264_omx).",
   "author": "oznu <dev@oz.nu>",
   "homepage": "https://github.com/homebridge/ffmpeg-for-homebridge#readme",


### PR DESCRIPTION
Removes the changes to automatically create the ARM build for Mac, as it seems to cause issues.