### PR TITLE
FFmpeg 6.0

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -335,8 +335,8 @@ if build "fdk_aac"; then
 fi
 
 if build "zlib"; then
-	download "https://www.zlib.net/zlib-1.2.12.tar.gz" "zlib-1.2.12.tar.gz"
-	cd $PACKAGES/zlib-1.2.12 || exit
+	download "https://www.zlib.net/zlib-1.2.13.tar.gz" "zlib-1.2.13.tar.gz"
+	cd $PACKAGES/zlib-1.2.13 || exit
 	execute ./configure --prefix=${WORKSPACE}
 	execute make -j $MJOBS
 	execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -347,7 +347,7 @@ if build "openssl"; then
 	download "https://www.openssl.org/source/openssl-1.1.1m.tar.gz" "openssl-1.1.1m.tar.gz"
 	cd $PACKAGES/openssl-1.1.1m || exit
 	if $MACOS_M1; then
-      sed -n 's/\(##### GNU Hurd\)/"darwin64-arm64-cc" => { \n    inherit_from     => [ "darwin-common", asm("aarch64_asm") ],\n    CFLAGS           => add("-Wall"),\n    cflags           => add("-arch arm64 "),\n    lib_cppflags     => add("-DL_ENDIAN"),\n    bn_ops           => "SIXTY_FOUR_BIT_LONG", \n    perlasm_scheme   => "macosx", \n}, \n\1/g' Configurations/10-main.conf
+      sed -n 's/\(##### GNU Hurd\)/"darwin64-arm64-cc" => { \n    inherit_from     => [ "darwin-common", asm("aarch64_asm") ],\n    CFLAGS           => add("-Wall"),\n    cflags           => add("-march arm64 "),\n    lib_cppflags     => add("-DL_ENDIAN"),\n    bn_ops           => "SIXTY_FOUR_BIT_LONG", \n    perlasm_scheme   => "macosx", \n}, \n\1/g' Configurations/10-main.conf
       execute ./Configure --prefix=${WORKSPACE} no-shared no-asm darwin64-arm64-cc
     else
       execute ./config --prefix=${WORKSPACE} --openssldir=${WORKSPACE} --with-zlib-include=${WORKSPACE}/include/ --with-zlib-lib=${WORKSPACE}/lib no-shared zlib

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -385,8 +385,8 @@ fi
 
 
 build "ffmpeg"
-download "https://ffmpeg.org/releases/ffmpeg-5.0.1.tar.bz2" "ffmpeg-5.0.1.tar.bz2"
-cd $PACKAGES/ffmpeg-5.0.1/ || exit
+download "https://ffmpeg.org/releases/ffmpeg-6.0.tar.bz2" "ffmpeg-6.0.tar.bz2"
+cd $PACKAGES/ffmpeg-6.0/ || exit
 ./configure $ADDITIONAL_CONFIGURE_OPTIONS \
     --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
     --prefix=${WORKSPACE} \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -344,8 +344,8 @@ if build "zlib"; then
 fi
 
 if build "openssl"; then
-	download "https://www.openssl.org/source/openssl-1.1.1m.tar.gz" "openssl-1.1.1m.tar.gz"
-	cd $PACKAGES/openssl-1.1.1m || exit
+	download "https://www.openssl.org/source/openssl-1.1.1t.tar.gz" "openssl-1.1.1t.tar.gz"
+	cd $PACKAGES/openssl-1.1.1t || exit
 	if $MACOS_M1; then
       sed -n 's/\(##### GNU Hurd\)/"darwin64-arm64-cc" => { \n    inherit_from     => [ "darwin-common", asm("aarch64_asm") ],\n    CFLAGS           => add("-Wall"),\n    cflags           => add("-march arm64 "),\n    lib_cppflags     => add("-DL_ENDIAN"),\n    bn_ops           => "SIXTY_FOUR_BIT_LONG", \n    perlasm_scheme   => "macosx", \n}, \n\1/g' Configurations/10-main.conf
       execute ./Configure --prefix=${WORKSPACE} no-shared no-asm darwin64-arm64-cc


### PR DESCRIPTION
## :recycle: Current situation

FFmpeg 5.0 is the current version being used by `ffmpeg-for-homebridge`

## :bulb: Proposed solution

Upgrade to FFmpeg 6.0

## :gear: Release Notes

Upgraded to FFmpeg 6.0

### Reviewer Nudging

@dgreif 